### PR TITLE
corrected north coast to read west coast

### DIFF
--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -29,7 +29,7 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
   public REGIONS: Array<Object> = [
     'Cariboo',
     'Kootney Boundary',
-    'North Coast',
+    'West Coast',
     'Northeast',
     'Omineca',
     'Skeena',
@@ -63,7 +63,7 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
     'Mount Waddington',
     'Nanaimo',
     'North Okanagan',
-    'North Coast',
+    'West Coast',
     'Okanagan - Similkameen',
     'Peace River',
     'qathet',


### PR DESCRIPTION
Simple change to a region which was erroneously labelled: "North Coast."

Updated both instances to read: "West Coast."

No projects in production are saved with "North Coast." 