### PR TITLE
Feature DESENG 51 - enable image upload functionality for CKEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update some methods with ES6 syntax
 * Remove unused function params, libraries, variables, etc.
 * Remove old, commented-out code
+* Enabled image uploading through CKEditor
 
 ### 1.0.0: October 22, 2021
 * Updating version in package.json, and changed package name to landuseplanning-admin

--- a/src/app/projects/add-edit-project/add-edit-project.component.html
+++ b/src/app/projects/add-edit-project/add-edit-project.component.html
@@ -190,7 +190,7 @@
       <h2>Background Information</h2>
       <div class="flex-container">
         <div class="add-row med">
-          <ckeditor name="backgroundInfo" id="backgroundInfo" formControlName="backgroundInfo" [editor]="Editor" [data]="project?.backgroundInfo"></ckeditor>
+          <ckeditor name="backgroundInfo" id="backgroundInfo" formControlName="backgroundInfo" [editor]="Editor" [data]="project?.backgroundInfo" (ready)="editorOnReady($event)"></ckeditor>
         </div>
       </div>
     </section>
@@ -205,7 +205,7 @@
         <div class="add-row med">
           <label for="enagementInfo">Engagement Tab Information </label>
           <ckeditor name="engagementInfo" id="engagementInfo" formControlName="engagementInfo" [editor]="Editor"
-            [data]="project?.engagementInfo"></ckeditor>
+            [data]="project?.engagementInfo" (ready)="editorOnReady($event)"></ckeditor>
           <label class="additional-label" for="engagementInfo">Appears at the top of the Engagement tab.</label>
         </div>
       </div>
@@ -216,7 +216,7 @@
         <div class="add-row med">
           <p>Additional information for the Documents tab</p>
           <ckeditor name="documentInfo" id="documentInfo" formControlName="documentInfo" [editor]="Editor"
-            [data]="project?.documentInfo"></ckeditor>
+            [data]="project?.documentInfo" (ready)="editorOnReady($event)"></ckeditor>
         </div>
       </div>
     </section>

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -739,7 +739,7 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
    * @param eventData Object type added and used by CK Editor
    * @returns {Promise}
    */
-  public editorOnReady(eventData: EventInfo): void {
+  public editorOnReady(eventData): void {
     // We need to grab our vars explicitely and pass them through to the CK Editor function.
     const projectId = this.projectId;
     const documentService = this.documentService;

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -739,7 +739,7 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
    * @param eventData Object type added and used by CK Editor
    * @returns {Promise}
    */
-  public editorOnReady(eventData) {
+  public editorOnReady(eventData: EventInfo): void {
     // We need to grab our vars explicitely and pass them through to the CK Editor function.
     const projectId = this.projectId;
     const documentService = this.documentService;

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -10,6 +10,7 @@ import { NgxSmartModalService } from 'ngx-smart-modal';
 import { StorageService } from 'app/services/storage.service';
 import { ProjectService } from 'app/services/project.service';
 import { DocumentService } from 'app/services/document.service';
+import { CkUploadAdapter } from 'app/shared/utils/ck-upload-adapter';
 import { Project } from 'app/models/project';
 import { NavigationStackUtils } from 'app/shared/utils/navigation-stack-utils';
 import { ModalData } from 'app/shared/types/modal';
@@ -730,6 +731,25 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
       duration: 2000,
     });
   }
+
+  /**
+   * Uses the CK Editor (ready) to link a file upload handler to the
+   * CK Editor instance.
+   * 
+   * @param eventData Object type added and used by CK Editor
+   * @returns {Promise}
+   */
+  public editorOnReady(eventData) {
+    // We need to grab our vars explicitely and pass them through to the CK Editor function.
+    const projectId = this.projectId;
+    const documentService = this.documentService;
+    const pathAPI = this.pathAPI;
+    eventData.plugins.get('FileRepository').createUploadAdapter = function (loader) {
+      return new CkUploadAdapter(loader, projectId, documentService, pathAPI);
+    };
+  }
+
+  register(myForm: FormGroup) { }
 
   ngOnDestroy() {
     this.ngUnsubscribe.next();

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -744,7 +744,7 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
     const projectId = this.projectId;
     const documentService = this.documentService;
     const pathAPI = this.pathAPI;
-    eventData.plugins.get('FileRepository').createUploadAdapter = function (loader) {
+    eventData.plugins.get('FileRepository').createUploadAdapter = (loader) => {
       return new CkUploadAdapter(loader, projectId, documentService, pathAPI);
     };
   }

--- a/src/app/shared/utils/ck-upload-adapter.spec.ts
+++ b/src/app/shared/utils/ck-upload-adapter.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { CkUploadAdapter } from "./ck-upload-adapter";
+import { DocumentService } from 'app/services/document.service';
+
+describe('CKUploadAdapter', () => {
+  describe('test upload()', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          DocumentService
+        ]
+      });
+    });
+    it('should return a promise', inject([DocumentService], (docService: DocumentService) => {
+      // Return our fake file wrapped in a Promise.
+      let fakeFile = new Promise(function(resolve, reject) {
+        resolve('some_url');
+      });
+      let myInstance = new CkUploadAdapter(fakeFile, '12345', docService, 'http://localhost');
+      // Super simple test just to verify that the class got created.
+      // Will expand the tests once we get the testing framework even running on our local machines.
+      expect(myInstance).toBeTruthy();
+    }));
+  });
+});

--- a/src/app/shared/utils/ck-upload-adapter.ts
+++ b/src/app/shared/utils/ck-upload-adapter.ts
@@ -60,7 +60,7 @@ export class CkUploadAdapter {
             },
             error => {
               // Leaving this console.log for now until we have tested and verified on the server.
-              console.log('CK upload error =', error);
+              console.error('CK upload error =', error);
               reject(error);
             },
             () => {

--- a/src/app/shared/utils/ck-upload-adapter.ts
+++ b/src/app/shared/utils/ck-upload-adapter.ts
@@ -53,7 +53,7 @@ export class CkUploadAdapter {
                   },
                   error => {
                     // Leaving this console.log for now until we have tested and verified on the server.
-                    console.log('CK publish error =', error);
+                    console.error('CK publish error =', error);
                     reject(error);
                   }
                 )

--- a/src/app/shared/utils/ck-upload-adapter.ts
+++ b/src/app/shared/utils/ck-upload-adapter.ts
@@ -1,0 +1,83 @@
+import { DocumentService } from 'app/services/document.service';
+
+// This utility function is a template directly from CK,
+// modified to use our existing DocumentService.
+// https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/upload-adapter.html
+
+export class CkUploadAdapter {
+  private imageURL: string;
+  private imageUploadData: FormData;
+
+  constructor(
+    private loader,
+    private projectId: string,
+    private documentService: DocumentService,
+    private pathAPI: string
+  ) {
+    this.imageUploadData = new FormData();
+  }
+
+  /**
+   * Required function for the CKUploadAdapter.
+   * Uploads the file using the DocumentService,
+   * Then returns the image URL wrapped in a Promise.
+   *
+   * @returns {Promise}
+   */
+  upload(): Promise<any> {
+    // The Object used by CK Editor is wrapped in a promise,
+    // so need to combine the promise with the Document Service Observable.
+    return this.loader.file
+      .then(file => new Promise((resolve, reject) => {
+        // Add the meta data for each uploaded image.
+        this.imageUploadData.append('upfile', file);
+        this.imageUploadData.append('project', this.projectId);
+        this.imageUploadData.append('documentFileName', file.name);
+        this.imageUploadData.append('displayName', file.name);
+        this.imageUploadData.append('documentSource', 'CKEDITOR');
+
+        // Use the DocumentService to upload the image through the API.
+        this.documentService.add(this.imageUploadData)
+          .subscribe(
+            (res) => {
+              // Once the image is uploaded, it needs to be published as well.
+              this.documentService.publish(res._id)
+                .subscribe(
+                  res => {
+                    const safeName = res.documentFileName.replace(/ /g, '_');
+                    this.imageURL = this.pathAPI + '/document/' + res._id + '/fetch/' + safeName;
+                    // Return in a format that CK is expecting.
+                    resolve({
+                      default: this.imageURL
+                    });
+                  },
+                  error => {
+                    // Leaving this console.log for now until we have tested and verified on the server.
+                    console.log('CK publish error =', error);
+                    reject(error);
+                  }
+                )
+            },
+            error => {
+              // Leaving this console.log for now until we have tested and verified on the server.
+              console.log('CK upload error =', error);
+              reject(error);
+            },
+            () => {
+              // Do nothing.
+            }
+          );
+
+      }));
+  }
+
+  /**
+  * Required function for the CKUploadAdapter.
+  * Does nothing right now, but is still expected.
+  * 
+  * @returns {void}
+  */
+  abort(): void {
+    // Do nothing since our DocumentService doesn't offer abort functionality.
+  }
+}


### PR DESCRIPTION
[-] Wrote a test or tests for code you added.
[X] Linted the files you touched.
[X] Wrote a doc block for each method you added.
[-] Add documentation to the README

Added a new utility class as outlined by https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/upload-adapter.html to enable image upload within the CKEditor instances while using our existing Document storage.