### PR TITLE
DESENG-869 Implement user-level workaround for file-related API crashing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Jul 8, 2025
 * Improved strictness of shape file usage in the project create/edit form. [DESENG-867](https://citz-gdx.atlassian.net/browse/DESENG-867)
+* Work around file upload issue that leads to API crashing [DESENG-869](https://citz-gdx.atlassian.net/browse/DESENG-869)
+  * Users now instructed to save project first before uploading any shapefiles or images
 
 ### Jul 3, 2025
 * Restore use of the image picker in survey WYSIWYG editors [DESENG-866](https://citz-gdx.atlassian.net/browse/DESENG-866)

--- a/src/app/projects/add-edit-project/add-edit-project.component.html
+++ b/src/app/projects/add-edit-project/add-edit-project.component.html
@@ -79,8 +79,9 @@
               <input
                 type="button"
                 id="logos"
+                [attr.disabled]="isEditing ? null : true"
                 class="btn btn-primary small-margin-bottom logos-button"
-                value="{{logos.length > 0 ? 'Reselect project logo(s)' : 'Select project logo(s)'}}"
+                value="{{!isEditing ? 'Please save project before selecting logo(s)' : 'Select project logo(s)'}}"
                 (click)="launchFilePicker('logos', 'Select project logo(s)', true, 'jpg, jpeg, png', ['image/jpeg', 'image/png'], 3, 'PROJECT')"
               >
               <input
@@ -95,8 +96,16 @@
         </div>
 				<div class="form-group mb-0 half-wide">
 					<label for="shapeFile">Upload Project Banner Image</label>
-					<app-file-upload *ngIf="!bannerImageDocument" [maxFiles]="1" [maxSize]="300" [showInfo]="false" [showList]="false" [files]="projectFiles"
-						(filesChange)="updateBannerDocument($event); projectFiles = []"></app-file-upload>
+          <div class="banner-disabled-msg" *ngIf="!isEditing">Please save project before selecting banner image</div>
+					<app-file-upload
+            *ngIf="!bannerImageDocument && isEditing"
+            [maxFiles]="1"
+            [maxSize]="300"
+            [showInfo]="false"
+            [showList]="false"
+            [files]="projectFiles"
+						(filesChange)="updateBannerDocument($event); projectFiles = []"
+          ></app-file-upload>
 					<br>
 					<div class="doc-list mb-3" *ngIf="bannerImageDocument">
 						<span class="cell name" [title]="bannerImageDocument.displayName || ''">
@@ -164,8 +173,9 @@
         <input
           type="button"
           id="shapefiles"
+          [attr.disabled]="isEditing ? null : true"
           class="btn btn-primary small-margin-bottom logos-button"
-          value="{{shapefiles?.length > 0 ? 'Add shapefile(s)' : 'Select shapefile(s)'}}"
+          value="{{!isEditing ? 'Please save project before selecting shapefile(s)' : 'Select project shapefile(s)'}}"
           (click)="launchFilePicker('shapefiles', 'Select project shapefile(s)', false, 'zip', ['application/zip'], 6, 'SHAPEFILE')"
         >
         <ul class="shapefile-list mb-3" *ngIf="shapefiles?.controls.length > 0">

--- a/src/app/projects/add-edit-project/add-edit-project.component.scss
+++ b/src/app/projects/add-edit-project/add-edit-project.component.scss
@@ -132,6 +132,12 @@ section .form-container-65 {
   flex-direction: column;
 }
 
+.banner-disabled-msg {
+  margin-top: 10px;
+  color: $bright-link-color;
+  font-weight: bold;
+}
+
 @media (max-width: 1200px) {
   section .form-container-65 {
     width: 100%;

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -132,7 +132,7 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
     .takeUntil(this.ngUnsubscribe)
     .subscribe((data: { project: Project }) => {
       if (data.project) {
-        this.isEditing = Object.keys(data).length === 0 && data.constructor === Object ? false : true;
+        this.isEditing = data.constructor === Object ? true : false;
         
         /**
          * When a user selects a project lead(and is taken to a new window),

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -133,7 +133,7 @@ export class AddEditProjectComponent implements OnInit, AfterViewInit, OnDestroy
     .subscribe((data: { project: Project }) => {
       if (data.project) {
         this.isEditing = Object.keys(data).length === 0 && data.constructor === Object ? false : true;
-
+        
         /**
          * When a user selects a project lead(and is taken to a new window),
          * make sure the project lead is brought over.


### PR DESCRIPTION
- Instructs user to first save project before uploading files, blocks file uploads in the UI
- Depending on the user need going forward, this could be subject to revision to something more convenient