### PR TITLE
bugfix/deseng959: Made external tool text optional. It will display the URL itself if it's missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Apr 29, 2026
+* Made external link text optional for comment period form external tool option. When empty, URL will be displayed. [DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)
+
 ### Apr 24, 2026
 * Fixed form input for external survey tool [DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)
   - Removed WYSIWYG editor for text input value

--- a/src/app/project/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
+++ b/src/app/project/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
@@ -155,7 +155,7 @@
                 name="externalToolPopupText" 
                 formControlName="externalToolPopupText" 
                 class="form-control external-tool-input" 
-                [required]="commentPeriodForm.value.commentingMethod === 'externalEngagementTool'" 
+                [required]="false"
             />
           </div>
         </div>


### PR DESCRIPTION
- Made external link text optional for comment period form external tool option. When empty, URL will be displayed. 

[DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)